### PR TITLE
Change rustup installation to use minimal profile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ ENV RUST_STABLE_TOOLCHAIN=1.37.0 \
     PATH=/usr/local/cargo/bin:${PATH}
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
-    sh -s -- -y --no-modify-path --default-toolchain=${RUST_STABLE_TOOLCHAIN}
+    sh -s -- -y --no-modify-path --default-toolchain=${RUST_STABLE_TOOLCHAIN} --profile=minimal
 
 RUN set -eux; \
     rustup component add clippy rustfmt; \


### PR DESCRIPTION
This changes the rustup install to use the new 'minimal' profile. Effectively, this means that docs won't be installed, since cargo and rustfmt are installed manually afterwards.

See: https://blog.rust-lang.org/2019/10/15/Rustup-1.20.0.html